### PR TITLE
Hotfix - Resolving Text Input Write Issues

### DIFF
--- a/automancy/elementals/atoms/text_input.py
+++ b/automancy/elementals/atoms/text_input.py
@@ -152,25 +152,13 @@ class TextInput(Elemental):
             None
 
         """
-        attempt_counter = 20
+        # Clear the current form value
+        if clear_first:
+            self.clear()
 
-        # Repeat the send_keys command until the text we intend to input is correctly entered (or until retry maximum is hit)
-        while self.value != text:
+        # Click the element just to make sure we have it selected
+        self.click()
 
-            # Clear the current form value
-            if clear_first:
-                self.clear()
-
-            # Click the element just to make sure we have it selected
-            self.click()
-
-            # Enter the value after making sure the element has focus
-            self.click()
-            self.element().send_keys(text)
-
-            # Raise an exception if our number of remaining attempts reaches 0
-            if attempt_counter == 0:
-                raise IOError('Unable to correctly write the expected text to the input field after 20 attempts.')
-
-            # Drop the tries remaining
-            attempt_counter -= 1
+        # Enter the value after making sure the element has focus
+        self.click()
+        self.element().send_keys(text)

--- a/automancy/elementals/atoms/text_input.py
+++ b/automancy/elementals/atoms/text_input.py
@@ -165,7 +165,7 @@ class TextInput(Elemental):
             self.click()
 
             # Enter the value after making sure the element has focus
-            self.element().send_keys(Keys.NULL)
+            self.click()
             self.element().send_keys(text)
 
             # Raise an exception if our number of remaining attempts reaches 0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name='Automancy',
-    version='0.5.6',
+    version='0.5.7',
     author='Jonathan Craig',
     author_email='blurr@iamtheblurr.com',
     long_description_content_type='text/markdown',


### PR DESCRIPTION
These changes attempt to improve how the `.write()` method of `TextInput` class operates.  It does two things.

1. Removes the use of `.send_keys(Keys.NULL)` before writing to the input field.  The use of Keys.NULL has begun to cause a visible special character to be written into the input field within the last month.  I don't know if it's the newest Chrome WebDriver or the newest version of Selenium, or both, but UI operations were failing when run on Linux but not Windows for some reason.
2. Removed the `while` loop in the method.  The utility of having a while loop is from an older time and I believe it's probably a waste, a safety/performance concern, or both now.