### PR TITLE
Resolving Deprecation Warnings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-midnight

--- a/automancy/core/elemental.py
+++ b/automancy/core/elemental.py
@@ -224,7 +224,7 @@ class Elemental(object):
         # Dimension values of component
         window_x_pos = self.browser.get_window_position()['x']
         window_width = self.browser.get_window_size()['width']
-        html_body_width = self.browser.find_element_by_xpath('//body').rect['width']
+        html_body_width = self.browser.find_elements(By.XPATH, '//body').rect['width']
 
         # The offset pixel amount from the screen for where the html body actually begins
         window_x_offset = window_width - html_body_width + window_x_pos
@@ -238,7 +238,7 @@ class Elemental(object):
         # Dimension values of component
         window_y_pos = self.browser.get_window_position()['y']
         window_height = self.browser.get_window_size()['height']
-        html_body_height = self.browser.find_element_by_xpath('//body').rect['height']
+        html_body_height = self.browser.find_elements(By.XPATH, '//body').rect['height']
 
         # The offset pixel amount from the screen for where the html body actually begins
         window_y_offset = window_height - html_body_height + window_y_pos
@@ -349,7 +349,7 @@ class Elemental(object):
             locator = other
 
         if self.valid_xpath(to_validate=locator):
-            elements = self.browser.find_elements_by_xpath(locator)
+            elements = self.browser.find_elements(By.XPATH, locator)
 
             if elements:
                 exists = True
@@ -606,7 +606,7 @@ class Elemental(object):
 
         """
         if self.browser:
-            return self.browser.find_elements_by_xpath(locator)
+            return self.browser.find_elements(By.XPATH, locator)
 
     def scroll_to(self):
         """

--- a/automancy/elementals/organisms/calendar/calendar.py
+++ b/automancy/elementals/organisms/calendar/calendar.py
@@ -1,7 +1,10 @@
 """ ./elementals/organisms/calendar/calendar.py """
+from selenium.webdriver.common.by import By
+
 from automancy.core import Elemental
 from automancy.elementals.atoms import Button, Label
 from automancy.core.tactical_asserts import TacticalAsserts
+
 from .calendar_day import CalendarDay
 from .calendar_week import CalendarWeek
 from .calendar_options import CalendarOptions
@@ -49,8 +52,8 @@ class Calendar(Elemental):
         # Clear the internal weeks array to reset the state
         self.weeks = []
 
-        # Find the the elements in the DOM that represent each of the weeks
-        found_week_elements = self.browser.find_elements_by_xpath(self.locator + self.week_row_locator)
+        # Find the elements in the DOM that represent each of the weeks
+        found_week_elements = self.browser.find_elements(By.XPATH, self.locator + self.week_row_locator)
 
         # Construct objects and their individual locators based on the index that they're found at.
         for index, week in enumerate(found_week_elements, start=1):

--- a/automancy/elementals/organisms/dropdown/dropdown.py
+++ b/automancy/elementals/organisms/dropdown/dropdown.py
@@ -171,7 +171,7 @@ class Dropdown(Elemental):
             try:
                 # This first check is to see if the element actually exists or not.
                 # The Firefox webdriver acts really weird sometimes and will find an extra element that doesn't exist.
-                if self.browser.find_element_by_xpath(option_locator):
+                if self.browser.find_elements(By.XPATH, option_locator):
                     # NOTE: Dropdowns which have complex sets of options which don't conform to W3C standards should skip the wait for visibility step.
                     #       In real world experiments, dropdowns with disconnected options have issues with visibility since not all options are always loaded in).
                     # if not self.disconnected_options:

--- a/automancy/elementals/organisms/grid/grid.py
+++ b/automancy/elementals/organisms/grid/grid.py
@@ -1,3 +1,6 @@
+""" ./elementals/organisms/grid/grid.py """
+from selenium.webdriver.common.by import By
+
 from automancy.core import Elemental
 from .grid_segment import GridSegment
 from .grid_segments import GridSegments
@@ -223,7 +226,7 @@ class Grid(Elemental):
             bool: True if caption segments are detected, False if not
 
         """
-        return self.browser.find_elements_by_xpath(self.segments_locator)
+        return self.browser.find_elements(By.XPATH, self.segments_locator)
 
     def include(self, elemental, overwrite=False):
         """

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name='Automancy',
-    version='0.5.7',
+    version='0.5.8',
     author='Jonathan Craig',
     author_email='blurr@iamtheblurr.com',
     long_description_content_type='text/markdown',
@@ -12,6 +12,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Software Development :: Quality Assurance',
         'Topic :: Software Development :: Testing',
         'Topic :: Internet :: WWW/HTTP :: Browsers'


### PR DESCRIPTION
These changes replace the deprecated use of `find_element_by_xpath(...)` with `find_elements(By.XPATH, ...)`