### PR TITLE
Adding kwargs to model add signature

### DIFF
--- a/automancy/core/model.py
+++ b/automancy/core/model.py
@@ -6,7 +6,7 @@ class Model(object):
     def __init__(self):
         self.__children = {}
 
-    def add(self, elemental_class, locator: str, human_name: str, system_name: str = '', overwrite: bool = False) -> None:
+    def add(self, elemental_class, locator: str, human_name: str, system_name: str = '', overwrite: bool = False, **kwargs) -> None:
         """
         Adds an Elemental based object as a child to this model
 
@@ -31,5 +31,5 @@ class Model(object):
         if not hasattr(self, system_name) or overwrite:
             # Takes the parent locator and adds the child locator to the end of it
             concatenated_locator = getattr(self, 'locator') + locator
-            setattr(self, system_name, elemental_class(concatenated_locator, human_name, system_name=system_name))
+            setattr(self, system_name, elemental_class(concatenated_locator, human_name, system_name=system_name, **kwargs))
             self.__children[system_name] = getattr(self, system_name)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name='Automancy',
-    version='0.5.9',
+    version='0.5.10',
     author='Jonathan Craig',
     author_email='blurr@iamtheblurr.com',
     long_description_content_type='text/markdown',

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -1,35 +1,42 @@
 import pytest
 
-from automancy import Modal
+from automancy import Button, Dropdown, DropdownOptions, Modal
+
+test_model = Modal('//div', 'Test Model Object', 'test_model')
 
 
 class TestModel(object):
     def test_model_object_can_be_instantiated(self):
-        test_model = Modal('//div', 'Test Model Object', 'test_model')
         assert test_model.locator == '//div'
         assert test_model.name == 'Test Model Object'
         assert test_model.system_name == 'test_model'
 
-    def test_system_name_creation(self):
-        pytest.skip('Not implemented yet')
+    def test_simple_add_elemental_to_model(self):
+        test_model.add(Button, '//button[contains(text(), "Super Cool Button")]', 'Super Cool Button', 'super_cool_button')
 
-    def test_exception_with_space_in_system_name(self):
-        pytest.skip('Not implemented yet')
+        assert hasattr(test_model, 'super_cool_button')
+        assert isinstance(test_model.super_cool_button, Button)
+        assert test_model.super_cool_button.locator == '//div//button[contains(text(), "Super Cool Button")]'
+        assert test_model.super_cool_button.name == 'Super Cool Button'
 
-    def test_overwrite_existing_model_component(self):
-        pytest.skip('Not implemented yet')
+    def test_complex_add_element_to_model_with_kwargs(self):
+        dropdown_options = DropdownOptions(
+            option_locator='//div[contains(text(), "Options Locator")]',
+            option_type='//div[contains(text(), "Option Type")]',
+            static_options='//div[contains(text(), "Static Options")]',
+            disconnected_options='//div[contains(text(), "Disconnected Options")]',
+            option_selector_extension='//div[contains(text(), "Option Selector Extension")]',
+            option_label_extension='//div[contains(text(), "Option Label Extension")]',
+        )
+        test_model.add(Dropdown, '//dropdown', 'Test Cool Dropdown', 'test_dropdown', options=dropdown_options)
 
-    def test_cannot_overwrite_existing_model_component_without_overwrite_being_true(self):
-        pytest.skip('Not implemented yet')
-
-    def test_added_component_is_concatenated_parent_plus_input(self):
-        pytest.skip('Not implemented yet')
-
-    def test_added_component_is_set_as_a_property_of_the_parent(self):
-        pytest.skip('Not implemented yet')
-
-    def test_added_component_exists_in_parent_children_property(self):
-        pytest.skip('Not implemented yet')
-
-    def test_added_components_properties_are_correct(self):
-        pytest.skip('Not implemented yet')
+        assert hasattr(test_model, 'test_dropdown')
+        assert isinstance(test_model.test_dropdown, Dropdown)
+        assert test_model.test_dropdown.locator == '//div//dropdown'
+        assert test_model.test_dropdown.name == 'Test Cool Dropdown'
+        assert test_model.test_dropdown.options_locator == dropdown_options.option_locator
+        assert test_model.test_dropdown.options_type == dropdown_options.option_type
+        assert test_model.test_dropdown.static_options == dropdown_options.static_options
+        assert test_model.test_dropdown.disconnected_options == dropdown_options.disconnected_options
+        assert test_model.test_dropdown.option_selector_extension == dropdown_options.option_selector_extension
+        assert test_model.test_dropdown.option_label_extension == dropdown_options.option_label_extension


### PR DESCRIPTION
These changes allow the `Model.add(...)` method to take `**kwargs`, allowing more complex objects which have more/different arguments than default to more easily be added programmatically.